### PR TITLE
Fixed negative challenge tokens

### DIFF
--- a/lib/requestpacket.js
+++ b/lib/requestpacket.js
@@ -10,6 +10,7 @@ var COUNTER_MIN = 1;
 var COUNTER_MAX = 65535;
 var counter = 1;
 var MAX_TOKEN = 2147483647;
+var MIN_TOKEN = -2147483648;
 var SESSION_BITMASK = 0x0F0F0F0F;
 
 var RequestPacket = module.exports = function (requestType, options) {
@@ -60,7 +61,7 @@ RequestPacket.write = function (packet) {
 
   if (packet.type === consts.STAT_TYPE) {
     if (typeof packet.challengeToken !== 'number' ||
-      packet.challengeToken <= 0 ||
+      packet.challengeToken <= MIN_TOKEN ||
       packet.challengeToken >= MAX_TOKEN) {
       throw new TypeError('challengeToken is missing or wrong');
     }

--- a/test/packet.test.js
+++ b/test/packet.test.js
@@ -231,7 +231,7 @@ describe('packet', function () {
       delete p.challengeToken;
       expect(fn).to.throw(Error, 'challengeToken is missing or wrong');
 
-      p.challengeToken = 0;
+      p.challengeToken = -2147483648;
       expect(fn).to.throw(Error, 'challengeToken is missing or wrong');
 
       p.challengeToken = 4147483647;


### PR DESCRIPTION
The challenge token is an INT32 according to Dinnerbone ( https://dinnerbone.com/blog/2011/10/14/minecraft-19-has-rcon-and-query/ ), so it can have a minimum value of -2147483648 ( https://en.wikipedia.org/wiki/Integer_(computer_science) ) and not 0. I've ran in to problems while testing this module with the latest MCPE versions (Nukkit/Clearsky/Genisys), because they were all generating a negative challenge token (at least a negative challenge token was printed in the debug output) and the module threw an exception at line 65/66 in this file. I've added a new variable with the lower INT32 limit and changed the challenge token check to check against this variable.
