### PR TITLE
handle byte, short and int32 as signed integers

### DIFF
--- a/lib/requestpacket.js
+++ b/lib/requestpacket.js
@@ -76,10 +76,10 @@ RequestPacket.write = function (packet) {
 
   bc.writeUInt8(0xFE);
   bc.writeUInt8(0xFD);
-  bc.writeUInt8(packet.type);
-  bc.writeUInt32BE(packet.sessionId);
+  bc.writeInt8(packet.type);
+  bc.writeInt32BE(packet.sessionId);
   if (sLength > 0) {
-    bc.writeUInt32BE(packet.challengeToken);
+    bc.writeInt32BE(packet.challengeToken);
   }
   if (pLength > 0) {
     bc.copy(packet.payload);
@@ -97,13 +97,13 @@ RequestPacket.parse = function (buf) {
     throw new Error('Error in Magic Field');
   }
 
-  packet.type = bc.readUInt8();
-  packet.sessionId = bc.readUInt32BE();
+  packet.type = bc.readInt8();
+  packet.sessionId = bc.readInt32BE();
   if (bc.length > bc.tell()) {
     switch (packet.type) {
       case consts.STAT_TYPE:
         //get the challengeToken
-        packet.challengeToken = bc.readUInt32BE();
+        packet.challengeToken = bc.readInt32BE();
         if (bc.eof()) {
           packet.type = consts.REQUEST_BASIC;
         }

--- a/lib/responsepacket.js
+++ b/lib/responsepacket.js
@@ -25,8 +25,8 @@ ResponsePacket.parse = function parsePacket(data) {
   log.debug('parsing packet');
   var res = new ResponsePacket();
 
-  res.type = bc.readUInt8(),
-  res.sessionId = bc.readUInt32BE(),
+  res.type = bc.readInt8(),
+  res.sessionId = bc.readInt32BE(),
 
   log.debug('response=%j', res);
 
@@ -46,7 +46,7 @@ ResponsePacket.parse = function parsePacket(data) {
       res.map = readString(bc);
       res.numplayers = parseInt(readString(bc), 10);
       res.maxplayers = parseInt(readString(bc), 10);
-      res.hostport = bc.readUInt16LE();
+      res.hostport = bc.readInt16LE();
       res.hostip = readString(bc);
     }
     else {
@@ -96,8 +96,8 @@ ResponsePacket.write = function (packet) {
   log.debug('writing response');
   var bc = new BufferCursor(new Buffer(MAX_PACKET_SIZE));
 
-  bc.writeUInt8(packet.type);
-  bc.writeUInt32BE(packet.sessionId);
+  bc.writeInt8(packet.type);
+  bc.writeInt32BE(packet.sessionId);
   switch (packet.type) {
     case consts.CHALLENGE_TYPE:
       var s = packet.challengeToken.toString();
@@ -139,7 +139,7 @@ ResponsePacket.write = function (packet) {
         writeString(bc, packet.map);
         writeString(bc, packet.numplayers);
         writeString(bc, packet.maxplayers);
-        bc.writeUInt16LE(packet.hostport);
+        bc.writeInt16LE(packet.hostport);
         writeString(bc, packet.hostip);
 
       }


### PR DESCRIPTION
In newer NodeJS versions, a RangeError is thrown when Buffer.writeUInt32BE is provided with a number out of range (e.g. a negative number). This causes problems with negative challenge tokens.

According to wiki.vg, int32, short and byte are signed integers (https://wiki.vg/Data_types)