### PR TITLE
Reject messages that contain additional bytes after the end of the packet

### DIFF
--- a/lib/responsepacket.js
+++ b/lib/responsepacket.js
@@ -83,6 +83,9 @@ ResponsePacket.parse = function parsePacket (data) {
   } else {
     throw new Error('Unknown response type: ' + res.type)
   }
+  if (bc.tell() < bc.length) {
+    throw new Error('Bytes remaining after end of response')
+  }
   return res
 }// end parsePacket
 


### PR DESCRIPTION
Strings in the Minecraft Query Protocol are null-terminated. By adding null-bytes (\u0000) to a server's MOTD in the server.properties file, other values in the query Response can be overwritten.
https://bugs.mojang.com/browse/MC-221987

This can (partially) be prevented, by checking that messages do not contain additional, unused bytes after the end of the actual packet.